### PR TITLE
Fix NotificationManager initialization in Home.py

### DIFF
--- a/Home.py
+++ b/Home.py
@@ -104,7 +104,7 @@ def initialize_global_services():
     notification_instance, notification_status = initialize_service_with_retry(
         "Notification manager",
         lambda: NotificationManager(
-            telegram_token=current_settings.telegram_token,
+            telegram_token=current_settings.telegram_bot_token,
             telegram_chat_id=current_settings.telegram_chat_id
         )
     )


### PR DESCRIPTION
## Summary
- use `telegram_bot_token` when instantiating `NotificationManager`

## Testing
- `pytest -q` *(fails: ResearchAgent.__init__() got an unexpected keyword argument 'mongodb_client')*

------
https://chatgpt.com/codex/tasks/task_e_68419e10e1b48332849571406087fbe0